### PR TITLE
Fixed syntax error in switch-case statement

### DIFF
--- a/C/C - 3/switch-case.c
+++ b/C/C - 3/switch-case.c
@@ -6,17 +6,21 @@ void main()
     printf("Enter the value of age\n");
     scanf("%d", &age);
 
-    switch(age)
-        case 18:
-            printf("adult");
-            printf("they can vote");
-            printf("they can drive");
+    switch(age) {
+        case 18: {
+            printf("adult\n");
+            printf("they can vote\n");
+            printf("they can drive\n");
             break;
-        case 10:
-            printf("Not adult");
-            printf("they can't vote");
-            printf("they can't drive");
+        }
+        case 10: {
+            printf("Not adult\n");
+            printf("they can't vote\n");
+            printf("they can't drive\n");
             break;
-        default:
-            printf("Invalid");
+        }
+        default: {
+            printf("Invalid\n");
+        }
+    }
 }


### PR DESCRIPTION
**Description**
This pull request fixes a syntax error in the `switch-case.c` file located in `C - 3` directory. The error was caused by missing curly braces around the `switch` statement and the `case` blocks. The corrected code now properly groups the `printf` statements and includes the necessary braces.

**Changes Made**
- Added curly braces around the `switch` statement.
- Grouped printf statements within case blocks with curly braces.
- Added newline characters in printf statements for better readability.

**Testing**
- Verified the code compiles without errors.
- Tested the functionality for different values of age.